### PR TITLE
Initial data model diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Current schemas are in https://simplifier.net/FinnishPHR
 
 *Initial version from an old architecture document, to be updated*
 
-![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fjokimaki%2Frfc%2Fgraphviz%2Fmodel.dot%3F4)
+![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fomahoito%2Frfc%2Fmaster%2Fmodel.dot%3F1)
 <!-- Increment the last number (after %3F) to invalidate gravizo and browser cache -->

--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ We are conforming with a classic RFC process to continuously maintain a dialogue
 Please see https://github.com/omahoito/rfc/projects/1 for the progress of requests.
 
 Current schemas are in https://simplifier.net/FinnishPHR
+
+## Data model
+
+*Initial version from an old architecture document, to be updated*
+
+![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fjokimaki%2Frfc%2Fgraphviz%2Fmodel.dot%3F4)
+<!-- Increment the last number (after %3F) to invalidate gravizo and browser cache -->

--- a/model.dot
+++ b/model.dot
@@ -1,0 +1,51 @@
+digraph model {
+    // 1) Download from http://www.graphviz.org/Download.php
+    // 2) dot -T png -o model.png model.dot
+    graph[overlap=false, splines=true];
+    node [shape=record, fontsize=10, fontname="Helvetica"];
+    edge [arrowhead="none"];
+  
+    // Nodes
+    Hyvinvointisuunnitelma
+    Hyvinvointitarkastus
+    Ammattilainen
+    Asiakas
+    Kansalainen
+    Omahoitosuunnitelma
+    Asiakastieto
+    Oire
+    Palvelutarve
+    Arvio
+    Tietämys
+    "Itsehoito-ohje"
+    Hyvinvointitieto
+    Koodisto
+    Potilastieto
+    "PHR-tieto"
+    "Sosiaalitoimen asiakastieto"
+    Reseptitieto
+    Lähetetieto
+    // Dummy node for 3 way relationship
+    OAP[shape=point width=0];
+    
+    // Edges
+    Ammattilainen -> Hyvinvointisuunnitelma
+    Hyvinvointisuunnitelma -> Asiakas[arrowhead="diamond"]
+    Asiakastieto -> Asiakas[arrowhead="diamond"]
+    Asiakas -> Kansalainen[arrowhead="empty"]
+    Hyvinvointitarkastus -> Kansalainen[arrowhead="diamond"]
+    Omahoitosuunnitelma -> Kansalainen[arrowhead="diamond"]
+    Kansalainen -> Oire
+    Oire -> OAP -> Palvelutarve -> Kansalainen
+    Arvio -> OAP
+    Arvio -> Tietämys[arrowhead="vee", style="dotted"]
+    Arvio -> "Itsehoito-ohje"
+    Arvio -> Hyvinvointitieto[arrowhead="vee", style="dotted"]
+    Hyvinvointitieto -> Kansalainen[arrowhead="diamond"]
+    Potilastieto -> Hyvinvointitieto[arrowhead="empty"]
+    "PHR-tieto" -> Hyvinvointitieto[arrowhead="empty"]
+    "Sosiaalitoimen asiakastieto" -> Hyvinvointitieto[arrowhead="empty"]
+    Reseptitieto -> Potilastieto -> Hyvinvointitieto[arrowhead="empty"]
+    Lähetetieto -> Hyvinvointitieto[arrowhead="empty"]
+    
+}


### PR DESCRIPTION
Initial data model from "liite 2.3-arkkitehtuuri.docx" as a graphviz dot file, rendered to README with gravizo.

Preview: 
![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fjokimaki%2Frfc%2Fgraphviz%2Fmodel.dot%3F4)